### PR TITLE
Corrección de error y test: "undefined" al hacer clic en un espacio vacío

### DIFF
--- a/src/public/index.css
+++ b/src/public/index.css
@@ -33,6 +33,7 @@ body {
 }
 
 .rows button {
+    margin: 3px;
     text-transform: uppercase;
     background-color: var(--background-button);
     font-size: 1.5rem;

--- a/src/public/index.js
+++ b/src/public/index.js
@@ -7,9 +7,10 @@ let currentDisplay = "";
 let operation = null;
 let reset = false;
 
+// Listener para los botones dentro del contenedor con clase "buttons"
 $buttons.addEventListener('click', async (e) => {
-    const nextAction = e.target.name
-    
+    const nextAction = e.target.tagName === 'BUTTON' ? e.target.name : 'no-button';
+        
     if (nextAction === "=") {
         const [firstArg, secondArg] = currentDisplay.split(operation)
 
@@ -47,16 +48,17 @@ $buttons.addEventListener('click', async (e) => {
         return renderDisplay('');
     }
 
-    if (operations.includes(nextAction)) {
-        operation = nextAction;
-    }
-
-    if (reset) {
-        reset = false;
-        operation = null;
-        renderDisplay(nextAction);
-    } else {
-        renderDisplay(currentDisplay + nextAction);
+    if (nextAction !== "no-button") {
+        if (operations.includes(nextAction)) {
+            operation = nextAction;
+        }
+        if (reset) {
+            reset = false;
+            operation = null;
+            renderDisplay(nextAction);
+        } else {
+            renderDisplay(currentDisplay + nextAction);
+        }
     }
 })
 

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -286,5 +286,16 @@ test.describe('test', () => {
     await page.getByRole('button', { name: 'c', exact: true }).click();
     await expect(page.getByTestId('display')).toHaveValue('')
   });
+
+  test('Al hacer clic en un elemento que no sea un botón, el display debería mantenerse igual', async ({ page }) => {
+    await page.goto('./');
+    
+    const displayInicial = await page.$eval('.display', (display) => display.value);
+    const buttonsDiv = await page.$('.buttons');  
+    await buttonsDiv.evaluateHandle((div) => div.click());
+    const displayActual = await page.$eval('.display', (display) => display.value);
+    
+    expect(displayActual).toBe(displayInicial);
+  });
 })
 


### PR DESCRIPTION
Corrección de error: Se resolvió el problema de "undefined" al hacer clic en un espacio vacío. Con su test correspondiente.