### PR TITLE
Se modificó el número de la última versión del producto: v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [1.3.4] 21-06-2023
+## [1.4.0] 21-06-2023
 ### Added
     -Operacion raiz.
     -Operacion decimal a binario.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [1.3.4] 21-06-2023
+### Added
+    -Operacion raiz.
+    -Operacion decimal a binario.
+    -Funcionalidad de modo oscuro y modo claro
+    -Se agrega el historial de operaciones en la calculadora y un boton para borrarlo
+    -Se agrego la funcionalidad para escribir desde el teclado
+    -Se agregaron test e2e correspondientes a todo lo anterior. 
+### Fixed
+    -Se resolvieron errores de undefined
+    -Se arreglo la funcionalidad del boton "C"
+    -Se implemento el uso de numeros negativos
+    
 ## [1.3.3] 19-06-2023
 ### Added
     -Se realizaron las conexiones del front con la api.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ReCalc v1.3.3
+# ReCalc v1.3.4
 
 Calculadora con funciones simples.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ReCalc v1.3.4
+# ReCalc v1.4.0
 
 Calculadora con funciones simples.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "src",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "description": "",
   "main": "src/cli.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "src",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "",
   "main": "src/cli.js",
   "scripts": {


### PR DESCRIPTION
Debiera ser v1.4.0 y no v1.3.4 porque se incorporaron nuevas funcionalidades además de corregir bugs